### PR TITLE
Win warning c4251 disable

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -15,6 +15,7 @@ endmacro()
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251")
     add_definitions(-DUNICODE)
     add_definitions(-DLIBXML_STATIC)
 endif()


### PR DESCRIPTION
a temporary workaround for #17 (since we use warning-as-error mode that blocks the build)
