### PR TITLE
`MetadataStream::remove()` works incorre

### DIFF
--- a/modules/vmdatasource/test/test_remove.cpp
+++ b/modules/vmdatasource/test/test_remove.cpp
@@ -352,6 +352,11 @@ TEST_F(TestRemovingSchema, RemoveAllAddSchema)
         newStream.open(TEST_FILE, vmf::MetadataStream::ReadOnly);
         bool result = newStream.load(TEST_SCHEMA_NAME);
         ASSERT_TRUE( result );
+        std::shared_ptr<vmf::MetadataSchema> schema = newStream.getSchema(TEST_SCHEMA_NAME);
+        std::vector< std::shared_ptr<vmf::MetadataDesc> > descs = schema->getAll();
+        ASSERT_EQ(descs.size(), 1);
+        std::shared_ptr<vmf::MetadataDesc> desc = descs[0];
+        ASSERT_EQ(desc->getMetadataName(), TEST_PROPERTY_NAME2);
         newStream.close();
     }
 }
@@ -385,6 +390,11 @@ TEST_F(TestRemovingSchema, RemoveOneAddSchema)
         newStream.open(TEST_FILE, vmf::MetadataStream::ReadOnly);
         bool result = newStream.load(TEST_SCHEMA_NAME);
         ASSERT_TRUE( result );
+        std::shared_ptr<vmf::MetadataSchema> schema = newStream.getSchema(TEST_SCHEMA_NAME);
+        std::vector< std::shared_ptr<vmf::MetadataDesc> > descs = schema->getAll();
+        ASSERT_EQ(descs.size(), 1);
+        std::shared_ptr<vmf::MetadataDesc> desc = descs[0];
+        ASSERT_EQ(desc->getMetadataName(), TEST_PROPERTY_NAME2);
         newStream.close();
     }
 }
@@ -416,6 +426,11 @@ TEST_F(TestRemovingSchema, RemoveOneAddSchemaBeforeSaving)
         newStream.open(TEST_FILE, vmf::MetadataStream::ReadOnly);
         bool result = newStream.load(TEST_SCHEMA_NAME);
         ASSERT_TRUE( result );
+        std::shared_ptr<vmf::MetadataSchema> schema = newStream.getSchema(TEST_SCHEMA_NAME);
+        std::vector< std::shared_ptr<vmf::MetadataDesc> > descs = schema->getAll();
+        ASSERT_EQ(descs.size(), 1);
+        std::shared_ptr<vmf::MetadataDesc> desc = descs[0];
+        ASSERT_EQ(desc->getMetadataName(), TEST_PROPERTY_NAME2);
         newStream.close();
     }
 }

--- a/modules/vmdatasource/test/test_remove.cpp
+++ b/modules/vmdatasource/test/test_remove.cpp
@@ -100,6 +100,7 @@ protected:
     vmf::vmf_string TEST_FIELD_NAME;
 };
 
+
 TEST_F(TestRemoving, RemoveOne)
 {
     vmf::MetadataStream newStream;
@@ -142,6 +143,7 @@ TEST_F(TestRemoving, RemoveOne)
     newStream2.close();
 }
 
+
 TEST_F(TestRemoving, RemoveSet)
 {
     {
@@ -166,6 +168,7 @@ TEST_F(TestRemoving, RemoveSet)
     }
 }
 
+
 TEST_F(TestRemoving, RemoveAll)
 {
     {
@@ -187,6 +190,7 @@ TEST_F(TestRemoving, RemoveAll)
         newStream.close();
     }
 }
+
 
 TEST_F(TestRemoving, RemoveWithReferences)
 {
@@ -220,6 +224,7 @@ TEST_F(TestRemoving, RemoveWithReferences)
     }
 }
 
+
 class TestRemovingSchema : public TestRemoving
 {
 protected:
@@ -239,6 +244,7 @@ protected:
 
     vmf::vmf_string TEST_SCHEMA_NAME_2;
 };
+
 
 TEST_F(TestRemovingSchema, RemoveOneSchema)
 {
@@ -260,6 +266,7 @@ TEST_F(TestRemovingSchema, RemoveOneSchema)
     }
 }
 
+
 TEST_F(TestRemovingSchema, RemoveUnknownSchema)
 {
     vmf::MetadataStream newStream;
@@ -268,6 +275,7 @@ TEST_F(TestRemovingSchema, RemoveUnknownSchema)
     std::shared_ptr<vmf::MetadataSchema> schemaForRemoving(new vmf::MetadataSchema("Invalid schema") );
     EXPECT_THROW(newStream.remove(schemaForRemoving), vmf::Exception);
 }
+
 
 TEST_F(TestRemovingSchema, RemoveAllSchemas)
 {
@@ -289,6 +297,7 @@ TEST_F(TestRemovingSchema, RemoveAllSchemas)
         newStream.close();
     }
 }
+
 
 TEST_F(TestRemovingSchema, RemoveAll)
 {
@@ -314,6 +323,72 @@ TEST_F(TestRemovingSchema, RemoveAll)
         newStream.close();
     }
 }
+
+
+TEST_F(TestRemovingSchema, RemoveAllAddSchema)
+{
+    {
+        vmf::MetadataStream newStream;
+        newStream.open(TEST_FILE, vmf::MetadataStream::ReadWrite);
+        newStream.load();
+        newStream.remove();
+        newStream.save();
+        newStream.close();
+
+        std::shared_ptr<vmf::MetadataSchema> newSchema;
+        newSchema = std::shared_ptr<vmf::MetadataSchema>(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
+        std::vector<vmf::FieldDesc> fields;
+        fields.push_back(vmf::FieldDesc(TEST_FIELD_NAME, vmf::Variant::type_integer));
+        descr1 = std::shared_ptr<vmf::MetadataDesc>(new vmf::MetadataDesc(TEST_PROPERTY_NAME2, fields));
+        newSchema->add(descr1);
+        newStream.reopen(vmf::MetadataStream::ReadWrite);
+        newStream.addSchema(newSchema);
+        newStream.save();
+        newStream.close();
+    }
+
+    {
+        vmf::MetadataStream newStream;
+        newStream.open(TEST_FILE, vmf::MetadataStream::ReadOnly);
+        bool result = newStream.load(TEST_SCHEMA_NAME);
+        ASSERT_TRUE( result );
+        newStream.close();
+    }
+}
+
+
+TEST_F(TestRemovingSchema, RemoveOneAddSchema)
+{
+    {
+        vmf::MetadataStream newStream;
+        newStream.open(TEST_FILE, vmf::MetadataStream::ReadWrite);
+        newStream.load();
+        auto schemaForRemoving = newStream.getSchema(TEST_SCHEMA_NAME);
+        newStream.remove(schemaForRemoving);
+        newStream.save();
+        newStream.close();
+
+        std::shared_ptr<vmf::MetadataSchema> newSchema;
+        newSchema = std::shared_ptr<vmf::MetadataSchema>(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
+        std::vector<vmf::FieldDesc> fields;
+        fields.push_back(vmf::FieldDesc(TEST_FIELD_NAME, vmf::Variant::type_integer));
+        descr1 = std::shared_ptr<vmf::MetadataDesc>(new vmf::MetadataDesc(TEST_PROPERTY_NAME2, fields));
+        newSchema->add(descr1);
+        newStream.reopen(vmf::MetadataStream::ReadWrite);
+        newStream.addSchema(newSchema);
+        newStream.save();
+        newStream.close();
+    }
+
+    {
+        vmf::MetadataStream newStream;
+        newStream.open(TEST_FILE, vmf::MetadataStream::ReadOnly);
+        bool result = newStream.load(TEST_SCHEMA_NAME);
+        ASSERT_TRUE( result );
+        newStream.close();
+    }
+}
+
 
 TEST_F(TestRemovingSchema, RemovingWithReferences)
 {

--- a/modules/vmdatasource/test/test_remove.cpp
+++ b/modules/vmdatasource/test/test_remove.cpp
@@ -335,12 +335,11 @@ TEST_F(TestRemovingSchema, RemoveAllAddSchema)
         newStream.save();
         newStream.close();
 
-        std::shared_ptr<vmf::MetadataSchema> newSchema;
-        newSchema = std::shared_ptr<vmf::MetadataSchema>(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
-        std::vector<vmf::FieldDesc> fields;
-        fields.push_back(vmf::FieldDesc(TEST_FIELD_NAME, vmf::Variant::type_integer));
-        descr1 = std::shared_ptr<vmf::MetadataDesc>(new vmf::MetadataDesc(TEST_PROPERTY_NAME2, fields));
-        newSchema->add(descr1);
+        std::shared_ptr<vmf::MetadataSchema> newSchema(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
+        VMF_METADATA_BEGIN(TEST_PROPERTY_NAME2);
+            VMF_FIELD_INT(TEST_FIELD_NAME);
+        VMF_METADATA_END(newSchema);
+
         newStream.reopen(vmf::MetadataStream::ReadWrite);
         newStream.addSchema(newSchema);
         newStream.save();
@@ -373,12 +372,11 @@ TEST_F(TestRemovingSchema, RemoveOneAddSchema)
         newStream.save();
         newStream.close();
 
-        std::shared_ptr<vmf::MetadataSchema> newSchema;
-        newSchema = std::shared_ptr<vmf::MetadataSchema>(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
-        std::vector<vmf::FieldDesc> fields;
-        fields.push_back(vmf::FieldDesc(TEST_FIELD_NAME, vmf::Variant::type_integer));
-        descr1 = std::shared_ptr<vmf::MetadataDesc>(new vmf::MetadataDesc(TEST_PROPERTY_NAME2, fields));
-        newSchema->add(descr1);
+        std::shared_ptr<vmf::MetadataSchema> newSchema(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
+        VMF_METADATA_BEGIN(TEST_PROPERTY_NAME2);
+            VMF_FIELD_INT(TEST_FIELD_NAME);
+        VMF_METADATA_END(newSchema);
+
         newStream.reopen(vmf::MetadataStream::ReadWrite);
         newStream.addSchema(newSchema);
         newStream.save();
@@ -409,12 +407,10 @@ TEST_F(TestRemovingSchema, RemoveOneAddSchemaBeforeSaving)
         auto schemaForRemoving = newStream.getSchema(TEST_SCHEMA_NAME);
         newStream.remove(schemaForRemoving);
 
-        std::shared_ptr<vmf::MetadataSchema> newSchema;
-        newSchema = std::shared_ptr<vmf::MetadataSchema>(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
-        std::vector<vmf::FieldDesc> fields;
-        fields.push_back(vmf::FieldDesc(TEST_FIELD_NAME, vmf::Variant::type_integer));
-        descr1 = std::shared_ptr<vmf::MetadataDesc>(new vmf::MetadataDesc(TEST_PROPERTY_NAME2, fields));
-        newSchema->add(descr1);
+        std::shared_ptr<vmf::MetadataSchema> newSchema(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
+        VMF_METADATA_BEGIN(TEST_PROPERTY_NAME2);
+            VMF_FIELD_INT(TEST_FIELD_NAME);
+        VMF_METADATA_END(newSchema);
         newStream.addSchema(newSchema);
 
         newStream.save();
@@ -444,12 +440,10 @@ TEST_F(TestRemovingSchema, RemoveOneAddSchemaNoSaving)
     auto schemaForRemoving = newStream.getSchema(TEST_SCHEMA_NAME);
     newStream.remove(schemaForRemoving);
 
-    std::shared_ptr<vmf::MetadataSchema> newSchema;
-    newSchema = std::shared_ptr<vmf::MetadataSchema>(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
-    std::vector<vmf::FieldDesc> fields;
-    fields.push_back(vmf::FieldDesc(TEST_FIELD_NAME, vmf::Variant::type_integer));
-    descr1 = std::shared_ptr<vmf::MetadataDesc>(new vmf::MetadataDesc(TEST_PROPERTY_NAME2, fields));
-    newSchema->add(descr1);
+    std::shared_ptr<vmf::MetadataSchema> newSchema(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
+    VMF_METADATA_BEGIN(TEST_PROPERTY_NAME2);
+        VMF_FIELD_INT(TEST_FIELD_NAME);
+    VMF_METADATA_END(newSchema);
     newStream.addSchema(newSchema);
 
     std::shared_ptr<vmf::MetadataSchema> schema = newStream.getSchema(TEST_SCHEMA_NAME);

--- a/modules/vmdatasource/test/test_remove.cpp
+++ b/modules/vmdatasource/test/test_remove.cpp
@@ -390,6 +390,37 @@ TEST_F(TestRemovingSchema, RemoveOneAddSchema)
 }
 
 
+TEST_F(TestRemovingSchema, RemoveOneAddSchemaBeforeSaving)
+{
+    {
+        vmf::MetadataStream newStream;
+        newStream.open(TEST_FILE, vmf::MetadataStream::ReadWrite);
+        newStream.load();
+        auto schemaForRemoving = newStream.getSchema(TEST_SCHEMA_NAME);
+        newStream.remove(schemaForRemoving);
+
+        std::shared_ptr<vmf::MetadataSchema> newSchema;
+        newSchema = std::shared_ptr<vmf::MetadataSchema>(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
+        std::vector<vmf::FieldDesc> fields;
+        fields.push_back(vmf::FieldDesc(TEST_FIELD_NAME, vmf::Variant::type_integer));
+        descr1 = std::shared_ptr<vmf::MetadataDesc>(new vmf::MetadataDesc(TEST_PROPERTY_NAME2, fields));
+        newSchema->add(descr1);
+        newStream.addSchema(newSchema);
+
+        newStream.save();
+        newStream.close();
+    }
+
+    {
+        vmf::MetadataStream newStream;
+        newStream.open(TEST_FILE, vmf::MetadataStream::ReadOnly);
+        bool result = newStream.load(TEST_SCHEMA_NAME);
+        ASSERT_TRUE( result );
+        newStream.close();
+    }
+}
+
+
 TEST_F(TestRemovingSchema, RemovingWithReferences)
 {
     {

--- a/modules/vmdatasource/test/test_remove.cpp
+++ b/modules/vmdatasource/test/test_remove.cpp
@@ -436,6 +436,32 @@ TEST_F(TestRemovingSchema, RemoveOneAddSchemaBeforeSaving)
 }
 
 
+TEST_F(TestRemovingSchema, RemoveOneAddSchemaNoSaving)
+{
+    vmf::MetadataStream newStream;
+    newStream.open(TEST_FILE, vmf::MetadataStream::ReadWrite);
+    newStream.load();
+    auto schemaForRemoving = newStream.getSchema(TEST_SCHEMA_NAME);
+    newStream.remove(schemaForRemoving);
+
+    std::shared_ptr<vmf::MetadataSchema> newSchema;
+    newSchema = std::shared_ptr<vmf::MetadataSchema>(new vmf::MetadataSchema(TEST_SCHEMA_NAME));
+    std::vector<vmf::FieldDesc> fields;
+    fields.push_back(vmf::FieldDesc(TEST_FIELD_NAME, vmf::Variant::type_integer));
+    descr1 = std::shared_ptr<vmf::MetadataDesc>(new vmf::MetadataDesc(TEST_PROPERTY_NAME2, fields));
+    newSchema->add(descr1);
+    newStream.addSchema(newSchema);
+
+    std::shared_ptr<vmf::MetadataSchema> schema = newStream.getSchema(TEST_SCHEMA_NAME);
+    ASSERT_NE(schema, nullptr);
+    std::vector< std::shared_ptr<vmf::MetadataDesc> > descs = schema->getAll();
+    ASSERT_EQ(descs.size(), 1);
+    std::shared_ptr<vmf::MetadataDesc> desc = descs[0];
+    ASSERT_EQ(desc->getMetadataName(), TEST_PROPERTY_NAME2);
+    newStream.close();
+}
+
+
 TEST_F(TestRemovingSchema, RemovingWithReferences)
 {
     {

--- a/modules/vmfcore/src/metadatastream.cpp
+++ b/modules/vmfcore/src/metadatastream.cpp
@@ -114,20 +114,22 @@ bool MetadataStream::save()
             dataSource->remove(removedIds);
             removedIds.clear();
 
-            for(auto schemaPtr = removedSchemas.begin(); schemaPtr != removedSchemas.end(); schemaPtr++)
+            for(auto& schemaPtr : removedSchemas)
             {
-                dataSource->removeSchema(schemaPtr->first);
-                if(schemaPtr->first == "")
+                dataSource->removeSchema(schemaPtr.first);
+                // Empty schema name is used to delete all schemas in the file
+                // That's why there's no need to continue the loop
+                if(schemaPtr.first == "")
                 {
                     break;
                 }
             }
             removedSchemas.clear();
 
-            for(auto p = m_mapSchemas.begin(); p != m_mapSchemas.end(); ++p)
+            for(auto& p : m_mapSchemas)
             {
-                dataSource->saveSchema(p->first, *this);
-                dataSource->save(p->second);
+                dataSource->saveSchema(p.first, *this);
+                dataSource->save(p.second);
             }
 
             dataSource->saveVideoSegments(videoSegments);

--- a/modules/vmfcore/src/metadatastream.cpp
+++ b/modules/vmfcore/src/metadatastream.cpp
@@ -114,21 +114,6 @@ bool MetadataStream::save()
             dataSource->remove(removedIds);
             removedIds.clear();
 
-            for(auto p = m_mapSchemas.begin(); p != m_mapSchemas.end(); ++p)
-            {
-                dataSource->saveSchema(p->first, *this);
-                dataSource->save(p->second);
-            }
-
-	        dataSource->saveVideoSegments(videoSegments);
-
-            dataSource->save(nextId);
-
-            if(!m_sChecksumMedia.empty())
-                dataSource->saveChecksum(m_sChecksumMedia);
-
-            addedIds.clear();
-
             for(auto schemaPtr = removedSchemas.begin(); schemaPtr != removedSchemas.end(); schemaPtr++)
             {
                 dataSource->removeSchema(schemaPtr->first);
@@ -138,6 +123,21 @@ bool MetadataStream::save()
                 }
             }
             removedSchemas.clear();
+
+            for(auto p = m_mapSchemas.begin(); p != m_mapSchemas.end(); ++p)
+            {
+                dataSource->saveSchema(p->first, *this);
+                dataSource->save(p->second);
+            }
+
+            dataSource->saveVideoSegments(videoSegments);
+
+            dataSource->save(nextId);
+
+            if(!m_sChecksumMedia.empty())
+                dataSource->saveChecksum(m_sChecksumMedia);
+
+            addedIds.clear();
 
             return true;
         }

--- a/modules/vmfcore/src/metadatastream.cpp
+++ b/modules/vmfcore/src/metadatastream.cpp
@@ -131,13 +131,13 @@ bool MetadataStream::save()
 
             for(auto schemaPtr = removedSchemas.begin(); schemaPtr != removedSchemas.end(); schemaPtr++)
             {
+                dataSource->removeSchema(schemaPtr->first);
                 if(schemaPtr->first == "")
                 {
-                    dataSource->removeSchema("");
                     break;
                 }
-                dataSource->removeSchema(schemaPtr->first);
             }
+            removedSchemas.clear();
 
             return true;
         }
@@ -550,6 +550,7 @@ void MetadataStream::clear()
     m_sFilePath = "";
     m_oMetadataSet.clear();
     m_mapSchemas.clear();
+    removedSchemas.clear();
     removedIds.clear();
     addedIds.clear();
     videoSegments.clear();


### PR DESCRIPTION
it blocks further metadata additions even after save/clear/close/reopen
