### PR TITLE
Fix VMF-2x compatibility

### DIFF
--- a/modules/vmdatasource/src/xmpschemasource.cpp
+++ b/modules/vmdatasource/src/xmpschemasource.cpp
@@ -248,17 +248,7 @@ shared_ptr<MetadataDesc> XMPSchemaSource::loadDescription(const MetaString& path
             VMF_EXCEPTION(DataStorageException, "Corrupted field by path " + currentFieldPath);
         }
 
-        Variant::Type type = Variant::type_unknown;
-        for(int i = 1;
-            Variant::typeToString(static_cast<Variant::Type>(i)) != Variant::typeToString(Variant::type_unknown); ++i)
-        {
-            MetaString nameOfType = Variant::typeToString(static_cast<Variant::Type>(i));
-            if (nameOfType == rawType)
-            {
-                type = static_cast<Variant::Type>(i);
-                break;
-            }
-        }
+        Variant::Type type = Variant::typeFromString(rawType);
 
         bool optional = true;
         if(!metadata->GetStructField(VMF_NS, currentFieldPath.c_str(), VMF_NS, FIELD_OPTIONALITY, NULL, NULL))

--- a/modules/vmfcore/src/variant.cpp
+++ b/modules/vmfcore/src/variant.cpp
@@ -50,11 +50,12 @@ public:
 
 Variant::Variant() : data(nullptr), m_type(type_unknown) {}
 
-Variant::Variant(const Variant& other) : data(other.data->clone()), m_type(other.getType()) {}
+Variant::Variant(const Variant& other) : data(other.data ? other.data->clone() : nullptr), m_type(other.getType()) {}
 
-Variant::Variant(Variant&& other)
+Variant::Variant(Variant&& other) : Variant()
 {
-    *this = std::move(other);
+    std::swap(data, other.data);
+    std::swap(m_type, other.m_type);
 }
 
 Variant::~Variant()
@@ -620,27 +621,28 @@ std::string Variant::typeToString(Type t)
 }
 
 #define TYPE_FROM_STRING( T , VAL) \
-    if(sFieldType == #VAL) \
-        return type_##T;
+    if(sFieldType == #VAL) return type_##T
 
 Variant::Type Variant::typeFromString(const std::string& sFieldType)
 {
-    TYPE_FROM_STRING( unknown , unknown )
-    TYPE_FROM_STRING( integer , integer )
-    TYPE_FROM_STRING( real , real )
-    TYPE_FROM_STRING( string , string )
-    TYPE_FROM_STRING( vec2d , vec2d )
-    TYPE_FROM_STRING( vec3d , vec3d )
-    TYPE_FROM_STRING( vec4d , vec4d )
-    TYPE_FROM_STRING( rawbuffer , rawbuffer )
-    TYPE_FROM_STRING( integer_vector , integer[] )
-    TYPE_FROM_STRING( real_vector , real[] )
-    TYPE_FROM_STRING( string_vector , string[] )
-    TYPE_FROM_STRING( vec2d_vector , vec2d[] )
-    TYPE_FROM_STRING( vec3d_vector , vec3d[] )
-    TYPE_FROM_STRING( vec4d_vector , vec4d[] )
+    TYPE_FROM_STRING(unknown, unknown);
+    TYPE_FROM_STRING(integer, char);
+    TYPE_FROM_STRING(integer, integer);
+    TYPE_FROM_STRING(real, real);
+    TYPE_FROM_STRING(string, string);
+    TYPE_FROM_STRING(vec2d, vec2d);
+    TYPE_FROM_STRING(vec3d, vec3d);
+    TYPE_FROM_STRING(vec4d, vec4d);
+    TYPE_FROM_STRING(rawbuffer, rawbuffer);
+    TYPE_FROM_STRING(integer_vector, char[]);
+    TYPE_FROM_STRING(integer_vector, integer[]);
+    TYPE_FROM_STRING(real_vector, real[]);
+    TYPE_FROM_STRING(string_vector, string[]);
+    TYPE_FROM_STRING(vec2d_vector, vec2d[]);
+    TYPE_FROM_STRING(vec3d_vector, vec3d[]);
+    TYPE_FROM_STRING(vec4d_vector, vec4d[]);
 
-    return type_unknown;
+    VMF_EXCEPTION(IncorrectParamException, std::string("Invalid type string: ") + sFieldType);
 }
 
 bool Variant::isConvertible(Type srcType, Type dstType)

--- a/modules/vmfcore/test/test_variant.cpp
+++ b/modules/vmfcore/test/test_variant.cpp
@@ -452,10 +452,11 @@ TEST_F(TestVariant, VectorFloatConstructor)
 
 TEST_F(TestVariant, typeFromString)
 {
-    ASSERT_EQ(v.typeFromString(""), vmf::Variant::type_unknown);
-    ASSERT_EQ(v.typeFromString("invalid type"), vmf::Variant::type_unknown);
+    ASSERT_THROW(v.typeFromString(""), vmf::IncorrectParamException);
+    ASSERT_THROW(v.typeFromString("invalid type"), vmf::IncorrectParamException);
 
     ASSERT_EQ(v.typeFromString("unknown"), vmf::Variant::type_unknown);
+    ASSERT_EQ(v.typeFromString("char"), vmf::Variant::type_integer); // removed char replaced with integer
     ASSERT_EQ(v.typeFromString("integer"), vmf::Variant::type_integer);
     ASSERT_EQ(v.typeFromString("real"), vmf::Variant::type_real);
     ASSERT_EQ(v.typeFromString("string"), vmf::Variant::type_string);
@@ -464,6 +465,7 @@ TEST_F(TestVariant, typeFromString)
     ASSERT_EQ(v.typeFromString("vec4d"), vmf::Variant::type_vec4d);
     ASSERT_EQ(v.typeFromString("rawbuffer"), vmf::Variant::type_rawbuffer);
 
+    ASSERT_EQ(v.typeFromString("char[]"), vmf::Variant::type_integer_vector); // removed char[] replaced with integer[]
     ASSERT_EQ(v.typeFromString("integer[]"), vmf::Variant::type_integer_vector);
     ASSERT_EQ(v.typeFromString("real[]"), vmf::Variant::type_real_vector);
     ASSERT_EQ(v.typeFromString("string[]"), vmf::Variant::type_string_vector);


### PR DESCRIPTION
fixing compatibility with VMF-2x after excluding `type_char` and `type_char_vector` from `Variant`
