### PR TITLE
Fix for iOS-64 compilation issue

### DIFF
--- a/3rdparty/xmp/third-party/zlib/gzguts.h
+++ b/3rdparty/xmp/third-party/zlib/gzguts.h
@@ -19,6 +19,11 @@
 #endif
 
 #include <stdio.h>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
 #include "zlib.h"
 #ifdef STDC
 #  include <string.h>


### PR DESCRIPTION
`/Users/itseez/Projects/VMF/vmf-3.0/vmf/3rdparty/xmp/third-party/zlib/gzlib.c:260:24:`
`error: implicit declaration of function 'lseek' is invalid in C99`
